### PR TITLE
Add a new port to the em-hdfs-namenode service

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -7,6 +7,7 @@ services:
         - "50070:50070"
         - "9000:9000"
         - "8020:8020"
+        - "8001:8001"
     hostname: edm-hdfs-namenode
     networks:
         - elastest


### PR DESCRIPTION
If you modify the docker-compose.yml file of the elastest-data-manager, you also need to perform the changes in the deploy/docker-compose.yml file.